### PR TITLE
docs: Standardize the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,17 @@ This repository holds all interfaces/classes/traits related to
 
 Note that this is not an HTTP link implementation of its own. It is merely an
 interface that describes an HTTP link. See the specification for more details.
+
+
+Link definition interfaces
+==============
+
+This repository holds all interfaces related to [PSR-13 (Link definition interfaces)][psr-url].
+
+Note that this is not a Link implementation of its own. It is merely interfaces that describe the components of a Link.
+
+You can find [implementations][implementation-url] and [installation instructions][package-url] for the specification on the packagist.
+
+[psr-url]: https://www.php-fig.org/psr/psr-13/
+[package-url]: https://packagist.org/packages/psr/link
+[implementation-url]: https://packagist.org/providers/psr/link-implementation

--- a/README.md
+++ b/README.md
@@ -1,13 +1,3 @@
-PSR Http Link
-=============
-
-This repository holds all interfaces/classes/traits related to
-[PSR-13](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-13-links.md).
-
-Note that this is not an HTTP link implementation of its own. It is merely an
-interface that describes an HTTP link. See the specification for more details.
-
-
 Link definition interfaces
 ==============
 
@@ -15,7 +5,7 @@ This repository holds all interfaces related to [PSR-13 (Link definition interfa
 
 Note that this is not a Link implementation of its own. It is merely interfaces that describe the components of a Link.
 
-You can find [implementations][implementation-url] and [installation instructions][package-url] for the specification on the packagist.
+The installable [package][package-url] and [implementations][implementation-url] are listed on Packagist.
 
 [psr-url]: https://www.php-fig.org/psr/psr-13/
 [package-url]: https://packagist.org/packages/psr/link


### PR DESCRIPTION
What:
Standardizes the README file providing a common language and an implementation link.

Why:
There are differences between PSR's READMEs in regarding language and the lacking of implementations references. So I've updated all READMEs using the https://github.com/php-fig/http-factory as base.