### PR TITLE
V3, add return types

### DIFF
--- a/src/EvolvableLinkInterface.php
+++ b/src/EvolvableLinkInterface.php
@@ -26,7 +26,7 @@ interface EvolvableLinkInterface extends LinkInterface
      *
      * @return static
      */
-    public function withHref(string|\Stringable $href): self;
+    public function withHref(string|\Stringable $href): static;
 
     /**
      * Returns an instance with the specified relationship included.
@@ -38,7 +38,7 @@ interface EvolvableLinkInterface extends LinkInterface
      *   The relationship value to add.
      * @return static
      */
-    public function withRel(string $rel): self;
+    public function withRel(string $rel): static;
 
     /**
      * Returns an instance with the specified relationship excluded.
@@ -50,7 +50,7 @@ interface EvolvableLinkInterface extends LinkInterface
      *   The relationship value to exclude.
      * @return static
      */
-    public function withoutRel(string $rel): self;
+    public function withoutRel(string $rel): static;
 
     /**
      * Returns an instance with the specified attribute added.
@@ -64,7 +64,7 @@ interface EvolvableLinkInterface extends LinkInterface
      *   The value of the attribute to set.
      * @return static
      */
-    public function withAttribute(string $attribute, string $value): self;
+    public function withAttribute(string $attribute, string $value): static;
 
     /**
      * Returns an instance with the specified attribute excluded.
@@ -76,5 +76,5 @@ interface EvolvableLinkInterface extends LinkInterface
      *   The attribute to remove.
      * @return static
      */
-    public function withoutAttribute(string $attribute): self;
+    public function withoutAttribute(string $attribute): static;
 }

--- a/src/EvolvableLinkInterface.php
+++ b/src/EvolvableLinkInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psr\Link;
 
 /**

--- a/src/EvolvableLinkInterface.php
+++ b/src/EvolvableLinkInterface.php
@@ -24,7 +24,7 @@ interface EvolvableLinkInterface extends LinkInterface
      *
      * @return static
      */
-    public function withHref(string|\Stringable $href);
+    public function withHref(string|\Stringable $href): self;
 
     /**
      * Returns an instance with the specified relationship included.
@@ -36,7 +36,7 @@ interface EvolvableLinkInterface extends LinkInterface
      *   The relationship value to add.
      * @return static
      */
-    public function withRel(string $rel);
+    public function withRel(string $rel): self;
 
     /**
      * Returns an instance with the specified relationship excluded.
@@ -48,7 +48,7 @@ interface EvolvableLinkInterface extends LinkInterface
      *   The relationship value to exclude.
      * @return static
      */
-    public function withoutRel(string $rel);
+    public function withoutRel(string $rel): self;
 
     /**
      * Returns an instance with the specified attribute added.
@@ -62,8 +62,7 @@ interface EvolvableLinkInterface extends LinkInterface
      *   The value of the attribute to set.
      * @return static
      */
-    public function withAttribute(string $attribute, string $value);
-
+    public function withAttribute(string $attribute, string $value): self;
 
     /**
      * Returns an instance with the specified attribute excluded.
@@ -75,5 +74,5 @@ interface EvolvableLinkInterface extends LinkInterface
      *   The attribute to remove.
      * @return static
      */
-    public function withoutAttribute(string $attribute);
+    public function withoutAttribute(string $attribute): self;
 }

--- a/src/EvolvableLinkProviderInterface.php
+++ b/src/EvolvableLinkProviderInterface.php
@@ -18,7 +18,7 @@ interface EvolvableLinkProviderInterface extends LinkProviderInterface
      *   A link object that should be included in this collection.
      * @return static
      */
-    public function withLink(LinkInterface $link);
+    public function withLink(LinkInterface $link): self;
 
     /**
      * Returns an instance with the specifed link removed.
@@ -31,5 +31,5 @@ interface EvolvableLinkProviderInterface extends LinkProviderInterface
      *   The link to remove.
      * @return static
      */
-    public function withoutLink(LinkInterface $link);
+    public function withoutLink(LinkInterface $link): self;
 }

--- a/src/EvolvableLinkProviderInterface.php
+++ b/src/EvolvableLinkProviderInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psr\Link;
 
 /**

--- a/src/EvolvableLinkProviderInterface.php
+++ b/src/EvolvableLinkProviderInterface.php
@@ -20,7 +20,7 @@ interface EvolvableLinkProviderInterface extends LinkProviderInterface
      *   A link object that should be included in this collection.
      * @return static
      */
-    public function withLink(LinkInterface $link): self;
+    public function withLink(LinkInterface $link): static;
 
     /**
      * Returns an instance with the specifed link removed.
@@ -33,5 +33,5 @@ interface EvolvableLinkProviderInterface extends LinkProviderInterface
      *   The link to remove.
      * @return static
      */
-    public function withoutLink(LinkInterface $link): self;
+    public function withoutLink(LinkInterface $link): static;
 }

--- a/src/LinkInterface.php
+++ b/src/LinkInterface.php
@@ -20,7 +20,7 @@ interface LinkInterface
      *
      * @return string
      */
-    public function getHref();
+    public function getHref(): string;
 
     /**
      * Returns whether or not this is a templated link.
@@ -28,7 +28,7 @@ interface LinkInterface
      * @return bool
      *   True if this link object is templated, False otherwise.
      */
-    public function isTemplated();
+    public function isTemplated(): bool;
 
     /**
      * Returns the relationship type(s) of the link.
@@ -38,7 +38,7 @@ interface LinkInterface
      *
      * @return string[]
      */
-    public function getRels();
+    public function getRels(): array;
 
     /**
      * Returns a list of attributes that describe the target URI.
@@ -48,5 +48,5 @@ interface LinkInterface
      *  is either a PHP primitive or an array of PHP strings. If no values are
      *  found an empty array MUST be returned.
      */
-    public function getAttributes();
+    public function getAttributes(): array;
 }

--- a/src/LinkInterface.php
+++ b/src/LinkInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psr\Link;
 
 /**

--- a/src/LinkProviderInterface.php
+++ b/src/LinkProviderInterface.php
@@ -13,7 +13,7 @@ interface LinkProviderInterface
      * The iterable may be an array or any PHP \Traversable object. If no links
      * are available, an empty array or \Traversable MUST be returned.
      *
-     * @return iterable[LinkInterface]
+     * @return iterable<LinkInterface>
      */
     public function getLinks(): iterable;
 
@@ -26,7 +26,7 @@ interface LinkProviderInterface
      * @param string $rel
      *   The relationship name for which to retrieve links.
      *
-     * @return iterable[LinkInterface]
+     * @return iterable<LinkInterface>
      */
     public function getLinksByRel(string $rel): iterable;
 }

--- a/src/LinkProviderInterface.php
+++ b/src/LinkProviderInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psr\Link;
 
 /**

--- a/src/LinkProviderInterface.php
+++ b/src/LinkProviderInterface.php
@@ -13,9 +13,9 @@ interface LinkProviderInterface
      * The iterable may be an array or any PHP \Traversable object. If no links
      * are available, an empty array or \Traversable MUST be returned.
      *
-     * @return LinkInterface[]|\Traversable
+     * @return iterable[LinkInterface]
      */
-    public function getLinks();
+    public function getLinks(): iterable;
 
     /**
      * Returns an iterable of LinkInterface objects that have a specific relationship.
@@ -26,7 +26,7 @@ interface LinkProviderInterface
      * @param string $rel
      *   The relationship name for which to retrieve links.
      *
-     * @return LinkInterface[]|\Traversable
+     * @return iterable[LinkInterface]
      */
-    public function getLinksByRel(string $rel);
+    public function getLinksByRel(string $rel): iterable;
 }


### PR DESCRIPTION
This includes the v2 parameter changes, because GitHub.

Note: `self` as a return type is cranky at times.  I am not sure if we should include it or leave that doc-only.  I made that a separate commit so it's easy to rebase out if we decide not to.  Input on that welcome.